### PR TITLE
Add AkashTrainer integration (Dockerfile + akash_train + publish_results)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,56 @@
+# OnePen training image — runnable on Akash via AkashTrainer or standalone.
+#
+# Contract with AkashTrainer:
+#   - AkashTrainer sets TRAIN_CMD (defaults to `python3 scripts/train.py --no-wandb`)
+#     and the GitHub push env vars (REPO_URL, GITHUB_TOKEN, OUTPUT_BRANCH_PREFIX).
+#   - This image's CMD honors $TRAIN_CMD via the `exec` form below.
+#   - scripts/train.py calls akash_train.publish_results() at the end, which
+#     pushes the trained model + metrics to a `trained-output/<timestamp>` branch.
+#
+# Standalone (docker run andyhuynh24/onepen-trainer:v1):
+#   - No TRAIN_CMD set → defaults to `python3 scripts/train.py --no-wandb`.
+#   - REPO_URL/GITHUB_TOKEN unset → publish_results writes /output/results.json
+#     locally but skips the git push.
+
+# NVIDIA's TF container (TF 2.17 + CUDA 12.8 with kernels for Blackwell/H100/A100/etc.)
+FROM nvcr.io/nvidia/tensorflow:25.02-tf2-py3
+
+WORKDIR /workspace/project
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends git \
+ && rm -rf /var/lib/apt/lists/*
+
+# OnePen's requirements.txt pins tensorflow>=2.20.0, which would override the
+# image's TF 2.17 (and likely break CUDA compat). Install only the non-TF deps
+# OnePen actually needs.
+RUN pip install --no-cache-dir \
+    "numpy>=1.24.0" \
+    "scikit-learn>=1.3.0" \
+    "pandas>=2.0.0" \
+    "pillow>=10.0.0" \
+    "pydantic>=2.0.0" \
+    "pydantic-settings>=2.0.0" \
+    "pyyaml>=6.0" \
+    "matplotlib>=3.7.0" \
+    "seaborn>=0.12.0" \
+    "rich>=13.0.0" \
+    "tf_keras"
+
+# Project files
+COPY config/        config/
+COPY scripts/       scripts/
+COPY src/           src/
+COPY data/processed/ data/processed/
+
+# AkashTrainer publish helper (stdlib + git CLI only)
+COPY akash_train.py akash_train.py
+
+RUN mkdir -p models /output outputs logs
+
+ENV PYTHONPATH="/workspace/project/src:/workspace/project"
+
+# Honor $TRAIN_CMD if AkashTrainer set it; otherwise run a sensible default.
+# --no-wandb is included so the container doesn't try to phone home to W&B
+# without an API key (set WANDB_API_KEY env var to enable W&B logging instead).
+CMD ["sh", "-c", "exec ${TRAIN_CMD:-python3 scripts/train.py --no-wandb}"]

--- a/akash_train.py
+++ b/akash_train.py
@@ -1,0 +1,239 @@
+"""akash_train — minimal helper for publishing training results back to GitHub.
+
+Designed to be called at the end of a training script running inside an
+AkashTrainer-launched container. AkashTrainer sets these env vars in the
+container before launch:
+
+    REPO_URL              https://github.com/user/repo
+    REPO_BRANCH           branch the training was started from
+    GITHUB_TOKEN          token with `repo` scope
+    OUTPUT_BRANCH_PREFIX  e.g. "trained-output/sweep-xyz/run-3"
+
+`publish_results()` writes a `results.json` (and optionally copies a model
+file) into an output directory, then `git push`es the directory to a new
+branch on REPO_URL. AkashTrainer's monitor reads the results.json off
+that branch and populates the leaderboard.
+
+Typical usage at the end of your training script:
+
+    from akash_train import publish_results
+
+    publish_results(
+        metrics={
+            "val_accuracy": float(history.history["val_accuracy"][-1]),
+            "val_loss": float(history.history["val_loss"][-1]),
+            "val_acc_curve": [float(x) for x in history.history["val_accuracy"]],
+        },
+        model_path="models/model.keras",  # optional
+        hyperparams={"lr": args.lr, "batch_size": args.batch_size},  # optional
+    )
+
+You can run the script locally without AkashTrainer — publish_results
+detects missing env vars and silently no-ops (returns False).
+"""
+
+from __future__ import annotations
+
+import datetime
+import json
+import os
+import shutil
+import subprocess
+import sys
+from typing import Any, Dict, Iterable, Optional
+
+__version__ = "0.1.0"
+__all__ = ["publish_results", "PublishResult"]
+
+
+class PublishResult:
+    """Return value from publish_results — tells caller what happened."""
+
+    def __init__(
+        self,
+        published: bool,
+        reason: Optional[str] = None,
+        branch: Optional[str] = None,
+        branch_url: Optional[str] = None,
+        output_dir: Optional[str] = None,
+    ) -> None:
+        self.published = published
+        self.reason = reason
+        self.branch = branch
+        self.branch_url = branch_url
+        self.output_dir = output_dir
+
+    def __bool__(self) -> bool:
+        return self.published
+
+    def __repr__(self) -> str:
+        if self.published:
+            return f"PublishResult(branch_url={self.branch_url!r})"
+        return f"PublishResult(published=False, reason={self.reason!r})"
+
+
+def _run(cmd: list[str], cwd: str, check: bool = True) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        cmd, cwd=cwd, check=check, capture_output=True, text=True
+    )
+
+
+def publish_results(
+    metrics: Optional[Dict[str, Any]] = None,
+    model_path: Optional[str] = None,
+    output_dir: str = "/output",
+    hyperparams: Optional[Dict[str, Any]] = None,
+    extra_files: Optional[Iterable[str]] = None,
+    success: bool = True,
+    extra_commit_lines: Optional[Iterable[str]] = None,
+    verbose: bool = True,
+) -> PublishResult:
+    """Write results.json + copy artifacts into output_dir, then git push to GitHub.
+
+    Args:
+        metrics: dict of metric_name -> number (or list of numbers for curves).
+            AkashTrainer treats scalar values as sortable leaderboard columns
+            and number-arrays as overlaid training curves.
+        model_path: optional path to a trained model file; copied into output_dir.
+        output_dir: where to stage files before pushing. Defaults to "/output"
+            (the AkashTrainer convention). Override for local testing.
+        hyperparams: optional dict echoing the hyperparameters used (drives
+            the parallel-coordinates plot on the sweep results page).
+        extra_files: iterable of additional file paths to include in the push.
+        success: whether to mark the commit message as success (🦞) or failure (❌).
+        extra_commit_lines: additional lines appended to the commit message body.
+        verbose: print status to stdout.
+
+    Returns:
+        PublishResult — truthy if pushed, falsy with a reason if skipped.
+
+    Skips silently (no exception) if REPO_URL or GITHUB_TOKEN env vars are
+    missing — so calling this from a local test run doesn't crash.
+    """
+
+    def log(msg: str) -> None:
+        if verbose:
+            print(f"[akash_train] {msg}", flush=True)
+
+    repo_url = os.environ.get("REPO_URL", "").strip()
+    token = os.environ.get("GITHUB_TOKEN", "").strip()
+    prefix = os.environ.get("OUTPUT_BRANCH_PREFIX", "trained-output/").rstrip("/")
+
+    os.makedirs(output_dir, exist_ok=True)
+
+    # Write results.json
+    payload: Dict[str, Any] = {
+        "timestamp": datetime.datetime.utcnow().isoformat() + "Z",
+        "success": bool(success),
+    }
+    if metrics:
+        payload.update(_normalize_metrics(metrics))
+    if hyperparams:
+        payload["hyperparams"] = _jsonable(hyperparams)
+
+    results_path = os.path.join(output_dir, "results.json")
+    with open(results_path, "w") as f:
+        json.dump(payload, f, indent=2, default=_jsonable)
+    log(f"wrote {results_path}")
+
+    # Copy model + extras
+    if model_path and os.path.exists(model_path):
+        dest = os.path.join(output_dir, os.path.basename(model_path))
+        try:
+            shutil.copy2(model_path, dest)
+            log(f"copied {model_path} → {dest}")
+        except (OSError, shutil.SameFileError) as e:
+            log(f"WARN could not copy model: {e}")
+
+    for extra in (extra_files or []):
+        if not os.path.exists(extra):
+            continue
+        dest = os.path.join(output_dir, os.path.basename(extra))
+        try:
+            if os.path.isdir(extra):
+                shutil.copytree(extra, dest, dirs_exist_ok=True)
+            else:
+                shutil.copy2(extra, dest)
+            log(f"copied {extra} → {dest}")
+        except (OSError, shutil.SameFileError) as e:
+            log(f"WARN could not copy {extra}: {e}")
+
+    # If we can't push, return now (local test path)
+    if not repo_url or not token:
+        reason = "REPO_URL and/or GITHUB_TOKEN not set — skipping git push (local test path)"
+        log(reason)
+        return PublishResult(published=False, reason=reason, output_dir=output_dir)
+
+    ts = datetime.datetime.utcnow().strftime("%Y%m%d-%H%M%S")
+    branch = f"{prefix}/{ts}"
+
+    auth_url = repo_url.replace("https://", "")
+    push_url = f"https://x-access-token:{token}@{auth_url}"
+
+    marker = "🦞 Training output" if success else "❌ Training failed"
+    status = "SUCCESS" if success else "FAILED"
+    cmd_line = " ".join(sys.argv)
+    commit_lines = [
+        f"{marker} — {datetime.datetime.utcnow().isoformat()}Z",
+        "",
+        f"Command: {cmd_line}",
+        f"STATUS: {status}",
+    ]
+    if extra_commit_lines:
+        commit_lines.extend(extra_commit_lines)
+    commit_msg = "\n".join(commit_lines)
+
+    try:
+        _run(["git", "init", "-q"], cwd=output_dir)
+        _run(["git", "checkout", "-q", "-b", branch], cwd=output_dir)
+        _run(["git", "add", "-A"], cwd=output_dir)
+        _run([
+            "git",
+            "-c", "user.email=akash@trainer.local",
+            "-c", "user.name=AkashTrainer",
+            "commit", "-q", "-m", commit_msg,
+        ], cwd=output_dir)
+        _run(["git", "push", "-q", push_url, branch], cwd=output_dir)
+    except subprocess.CalledProcessError as e:
+        reason = f"git push failed: {e.stderr.strip() or e}"
+        log(reason)
+        return PublishResult(published=False, reason=reason, output_dir=output_dir, branch=branch)
+
+    branch_url = f"{repo_url.rstrip('/').replace('.git', '')}/tree/{branch}"
+    log(f"✅ pushed {branch_url}")
+    return PublishResult(
+        published=True, branch=branch, branch_url=branch_url, output_dir=output_dir,
+    )
+
+
+def _normalize_metrics(metrics: Dict[str, Any]) -> Dict[str, Any]:
+    """Coerce metric values to plain JSON-friendly numbers / lists.
+
+    Catches numpy scalars, torch tensors (via .item()), etc.
+    """
+    out: Dict[str, Any] = {}
+    for k, v in metrics.items():
+        out[k] = _jsonable(v)
+    return out
+
+
+def _jsonable(v: Any) -> Any:
+    # Try torch tensor → python
+    if hasattr(v, "item") and callable(getattr(v, "item")):
+        try:
+            return v.item()
+        except Exception:
+            pass
+    # numpy / tensorflow scalars
+    if hasattr(v, "tolist") and callable(getattr(v, "tolist")):
+        try:
+            return v.tolist()
+        except Exception:
+            pass
+    if isinstance(v, (list, tuple)):
+        return [_jsonable(x) for x in v]
+    if isinstance(v, dict):
+        return {str(k): _jsonable(x) for k, x in v.items()}
+    if isinstance(v, (str, int, float, bool)) or v is None:
+        return v
+    return str(v)

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -392,6 +392,52 @@ def main() -> int:
     logger.info(f"  Outputs: {output_dir}")
     logger.info("=" * 60)
 
+    # --- AkashTrainer integration ---------------------------------------------
+    # Publish metrics + model back to source GitHub repo so AkashTrainer's
+    # monitor picks them up. No-ops gracefully when REPO_URL / GITHUB_TOKEN
+    # aren't set (local dev path).
+    try:
+        sys.path.insert(0, str(Path(__file__).parent.parent))
+        from akash_train import publish_results
+
+        hist = history.history if hasattr(history, "history") else {}
+        arr = lambda k: [float(x) for x in (hist.get(k) or [])]
+
+        result = publish_results(
+            success=True,
+            metrics={
+                "test_accuracy": float(test_metrics["test_accuracy"]),
+                "test_loss": float(test_metrics["test_loss"]),
+                "val_accuracy": float(best_metrics["best_val_accuracy"]),
+                "val_loss": float(best_metrics["best_val_loss"]),
+                "macro_f1": float(report["macro avg"]["f1-score"]),
+                "macro_precision": float(report["macro avg"]["precision"]),
+                "macro_recall": float(report["macro avg"]["recall"]),
+                "weighted_f1": float(report["weighted avg"]["f1-score"]),
+                "epochs_trained": int(best_metrics["epochs_trained"]),
+                "final_train_accuracy": float(best_metrics["final_train_accuracy"]),
+                # Per-epoch curves render as overlaid training-curve charts in the UI
+                "train_acc_curve": arr("accuracy"),
+                "val_acc_curve": arr("val_accuracy"),
+                "train_loss_curve": arr("loss"),
+                "val_loss_curve": arr("val_loss"),
+            },
+            model_path=str(model_path) if Path(model_path).exists() else None,
+            hyperparams={
+                "model_type": model_type,
+                "backbone": backbone_name,
+                "epochs": epochs,
+                "batch_size": batch_size,
+                "learning_rate": float(config.training.learning_rate),
+            },
+        )
+        if result:
+            logger.info(f"✅ Published to {result.branch_url}")
+        else:
+            logger.info(f"(akash_train) {result.reason}")
+    except Exception as e:
+        logger.warning(f"Could not publish results via akash_train: {e}")
+
     return 0
 
 


### PR DESCRIPTION
## What

Makes OnePen drivable from [AkashTrainer](https://github.com/AndyHuynh24/akashtrainer) for parallel hyperparameter sweeps on Akash Network GPUs, without changing the local-dev workflow.

## Changes (3 files, +341 lines, 0 deletions)

### `akash_train.py` (new, stdlib + git CLI only)
Minimal helper. Wraps everything in try/except so failures here never fail training.

### `Dockerfile` (new)
- `FROM nvcr.io/nvidia/tensorflow:25.02-tf2-py3` — NVIDIA TF container with kernels for Blackwell + H100 + A100 + RTX3090.
- Intentionally skips `pip install tensorflow` from requirements.txt. Installing TF 2.20 over NVIDIA's pre-built 2.17 would break CUDA bindings.
- `CMD ["sh", "-c", "exec ${TRAIN_CMD:-python3 scripts/train.py --no-wandb}"]` honors AkashTrainer-set commands per sweep run.

### `scripts/train.py` (~50 lines appended)
Before the final `return 0`, calls `publish_results(...)` with test/val accuracy, macro F1, per-epoch curves, hyperparams, and model path. Wrapped in try/except. **Local-dev unchanged**: without `REPO_URL`/`GITHUB_TOKEN` env vars, the helper writes results.json to `/output` locally but skips the git push.

## Sweep usage (after merge + image rebuild)

```
Base cmd:        python3 scripts/train.py --no-wandb --epochs 30
Container image: andyhuynh24/onepen-trainer:v1
Search space:
  --backbone     choice: mobilenetv3_small, mobilenetv3_large, efficientnetv2
  --model-type   choice: hybrid, image_only
Grid:            6 runs total
Primary metric:  test_accuracy
```

## Pre-built image

`andyhuynh24/onepen-trainer:v1` is already on Docker Hub (digest `sha256:fd6e103797f34146...`, 8.77 GB). Runnable today; this PR gets the source changes upstream so future image rebuilds use these files directly instead of patches applied at build time.

## Tested

- `python3 -m py_compile scripts/train.py` ✓
- `python3 -m py_compile akash_train.py` ✓
- Docker image built + pushed cleanly to `andyhuynh24/onepen-trainer:v1`
- Standalone `docker run` of the image starts training with the baked data without REPO_URL set (publish step gracefully no-ops)
