### PR TITLE
❌ Training failed — Jun 12, 2026 04:07 UTC

### DIFF
--- a/trained_output/TRAINING_FAILED.md
+++ b/trained_output/TRAINING_FAILED.md
@@ -1,0 +1,15 @@
+# ❌ Training Failed
+
+- **Date**: Jun 12, 2026 04:07 UTC
+- **Command**: `andyhuynh24/onepen-trainer:latest-v3 --model hybrid`
+- **Duration**: 0s
+- **GPU**: NVIDIA RTX PRO 6000 Blackwell Server Edition
+- **Exit code**: 127
+
+## Error Log (last 20 lines)
+
+```
+/entrypoint.sh: line 132: andyhuynh24/onepen-trainer:latest-v3: No such file or directory
+```
+
+Trained on Akash Network decentralized GPU cloud.


### PR DESCRIPTION
## Training Error

- **Exit code**: 127
- **Duration**: 0s
- **GPU**: NVIDIA RTX PRO 6000 Blackwell Server Edition

See trained_output/TRAINING_FAILED.md for details.